### PR TITLE
Slack Integration - Correction into the process of passing user query and AI response values

### DIFF
--- a/frontend/app/api/slack/events/route.ts
+++ b/frontend/app/api/slack/events/route.ts
@@ -34,6 +34,11 @@ export async function POST(req: Request) {
 
     const json = await response.json()
 
+    const payload_value = JSON.stringify({
+      user_input: data.event.text,
+      ai_response: json.data.content
+    })
+
     const messageBlocks = [
       {
         type: 'section',
@@ -51,7 +56,8 @@ export async function POST(req: Request) {
               type: 'plain_text',
               text: 'Share a feedback'
             },
-            action_id: 'feedback'
+            action_id: 'feedback',
+            value: payload_value
           }
         ]
       }
@@ -60,7 +66,8 @@ export async function POST(req: Request) {
     await web.chat.postMessage({
       blocks: messageBlocks,
       thread_ts: data.event.ts,
-      channel: data.event.channel
+      channel: data.event.channel,
+      text: json.data.content
     })
 
     return new Response(data.challenge, {

--- a/frontend/app/api/slack/interaction/route.ts
+++ b/frontend/app/api/slack/interaction/route.ts
@@ -17,11 +17,12 @@ export async function POST(req: Request) {
       ts: payload.message.ts
     })
 
+    const payload_value = JSON.parse(action.value)
     const question =
-      (thread as any)?.messages[0]?.text ||
+      payload_value.user_input ||
       'Something went wrong, please copy paste the question.'
     const answer =
-      (thread as any)?.messages[1]?.text ||
+      payload_value.ai_response ||
       'Something went wrong, please copy paste the answer.'
 
     await openModal(payload.trigger_id, question, answer)


### PR DESCRIPTION
@droegier 

This PR implements a change to send the values of user input and AI responses into the feedback modal. This allows the modal to correctly display these messages as intended in the specification.

I initially organized the values into a JSON structure but passed them as strings, as required for passing values to block elements in Slack. Subsequently, I parsed them back into JSON format for use in the Modal in slack/interaction/route.ts.