### PR TITLE
Integration between Slack and Notion for Expert Feedback

### DIFF
--- a/slack/api/slack/interaction.ts
+++ b/slack/api/slack/interaction.ts
@@ -6,143 +6,259 @@ const web = new WebClient(process.env.SLACK_TOKEN);
 export default async function POST(req: VercelRequest, res: VercelResponse) {
   const { body } = req;
   const data = body;
-  console.log(data);
-  const payload = JSON.parse(data["payload"] as string);
-  console.log(payload);
-  const action = payload.actions[0];
-  console.log(action);
 
-  if (
-    (payload.callback_id === "feedback" && payload.trigger_id) ||
-    (action.action_id === "feedback" &&
-      payload.trigger_id &&
-      payload.type === "block_actions")
-  ) {
-    // get rid of this
-    const thread = await web.conversations.replies({
-      channel: payload.channel.id,
-      ts: payload.message.ts,
-    });
+  try {
+    if (!data.payload) {
+      console.log("Payload is missing in the request body:", data);
+      throw new Error("Payload is missing");
+    }
+    const payload = JSON.parse(data.payload);
 
-    const payload_value = JSON.parse(action.value);
-    const question =
-      payload_value.user_input ||
-      "Something went wrong, please copy paste the question.";
-    const answer =
-      payload_value.ai_response ||
-      "Something went wrong, please copy paste the answer.";
+    if (payload.type === "block_actions") {
+      if (!payload.actions || payload.actions.length === 0) {
+        throw new Error("No actions found in payload");
+      }
 
-    await openModal(payload.trigger_id, question, answer);
-  }
+      const action = payload.actions[0];
 
-  if (payload.type === "view_submission") {
-    console.log(JSON.stringify(payload.view.blocks));
+      if (action.action_id === "static_select-action") {
+        return res.status(200).send("Ok");
+      }
 
-    /// submit to Notion
+      if (!action.value) {
+        console.log("Action value is undefined:", action);
+        throw new Error("Action value is undefined");
+      }
 
-    return res.status(200).json({ response_action: "clear" });
+      try {
+        const payload_value = JSON.parse(action.value);
+        const question =
+          payload_value.user_input ||
+          "Something went wrong, please copy paste the question.";
+        const answer =
+          payload_value.ai_response ||
+          "Something went wrong, please copy paste the answer.";
+        const slack_channel = payload_value.slack_channel;
+        const slack_thread_ts = payload_value.slack_thread_ts;
+
+        if (
+          (payload.callback_id === "feedback" && payload.trigger_id) ||
+          (action.action_id === "feedback" &&
+            payload.trigger_id &&
+            payload.type === "block_actions")
+        ) {
+          await openModal(
+            payload.trigger_id,
+            question,
+            answer,
+            slack_channel,
+            slack_thread_ts
+          );
+        }
+      } catch (error) {
+        console.error("Error parsing action value:", action.value);
+        throw error;
+      }
+    } else if (payload.type === "view_submission") {
+      console.log("payload.view.blocks:", payload.view.blocks);
+
+      const submittedValues = payload.view.state.values;
+      const selectActionKey = Object.keys(submittedValues).find(
+        (key) => submittedValues[key]["static_select-action"]
+      );
+      const textInputKey = Object.keys(submittedValues).find(
+        (key) => submittedValues[key]["plain_text_input-action"]
+      );
+
+      let correct = false;
+      let comment = "";
+      if (selectActionKey) {
+        const staticSelectAction =
+          submittedValues[selectActionKey]["static_select-action"];
+        correct = staticSelectAction.selected_option.value === "correct";
+      }
+      if (textInputKey) {
+        const textInputAction =
+          submittedValues[textInputKey]["plain_text_input-action"];
+        comment = textInputAction.value;
+      }
+      const expert = payload.user;
+      const { question, answer, slack_channel, slack_thread_ts } = JSON.parse(
+        payload.view.private_metadata
+      );
+
+      await submitToNotion(
+        question,
+        answer,
+        correct,
+        comment,
+        expert,
+        slack_channel,
+        slack_thread_ts
+      );
+
+      return res.status(200).json({ response_action: "clear" });
+    }
+  } catch (error) {
+    console.error("Error processing request:", error);
+    return res.status(400).json("Bad Request");
   }
 
   return res.status(200).send("Ok");
 }
 
-const openModal = async (trigger: string, question: string, answer: string) => {
-  const result = await web.views.open({
-    trigger_id: trigger,
-    view: {
-      type: "modal",
-      title: {
-        type: "plain_text",
-        text: "Law Bot Expert Feedback",
-        emoji: true,
-      },
-      submit: {
-        type: "plain_text",
-        text: "Submit",
-        emoji: true,
-      },
-      close: {
-        type: "plain_text",
-        text: "Cancel",
-        emoji: true,
-      },
-      blocks: [
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: "Was the answer correct?",
+const openModal = async (
+  trigger: string,
+  question: string,
+  answer: string,
+  slack_channel: string,
+  slack_thread_ts: string
+) => {
+  try {
+    const result = await web.views.open({
+      trigger_id: trigger,
+      view: {
+        type: "modal",
+        title: {
+          type: "plain_text",
+          text: "Law Bot Expert Feedback",
+          emoji: true,
+        },
+        submit: {
+          type: "plain_text",
+          text: "Submit",
+          emoji: true,
+        },
+        close: {
+          type: "plain_text",
+          text: "Cancel",
+          emoji: true,
+        },
+        private_metadata: JSON.stringify({
+          question,
+          answer,
+          slack_channel,
+          slack_thread_ts,
+        }),
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "Was the answer correct?",
+            },
+            accessory: {
+              type: "static_select",
+              placeholder: {
+                type: "plain_text",
+                text: "Select an item",
+                emoji: true,
+              },
+              options: [
+                {
+                  text: {
+                    type: "plain_text",
+                    text: "Yes",
+                    emoji: true,
+                  },
+                  value: "correct",
+                },
+                {
+                  text: {
+                    type: "plain_text",
+                    text: "No",
+                    emoji: true,
+                  },
+                  value: "false",
+                },
+              ],
+              action_id: "static_select-action",
+            },
           },
-          accessory: {
-            type: "static_select",
-            placeholder: {
+          {
+            type: "input",
+            element: {
+              type: "plain_text_input",
+              multiline: true,
+              action_id: "plain_text_input-action",
+            },
+            label: {
               type: "plain_text",
-              text: "Select an item",
+              text: "Your Expert Comment",
               emoji: true,
             },
-            options: [
+          },
+          {
+            type: "header",
+            text: {
+              type: "plain_text",
+              text: "Question & Bot's Answer",
+              emoji: true,
+            },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: question,
+            },
+          },
+          {
+            type: "context",
+            elements: [
               {
-                text: {
-                  type: "plain_text",
-                  text: "Yes",
-                  emoji: true,
-                },
-                value: "correct",
-              },
-              {
-                text: {
-                  type: "plain_text",
-                  text: "No",
-                  emoji: true,
-                },
-                value: "false",
+                type: "plain_text",
+                text: answer,
+                emoji: true,
               },
             ],
-            action_id: "static_select-action",
           },
-        },
-        {
-          type: "input",
-          element: {
-            type: "plain_text_input",
-            multiline: true,
-            action_id: "plain_text_input-action",
-          },
-          label: {
-            type: "plain_text",
-            text: "Your Expert Comment",
-            emoji: true,
-          },
-        },
-        {
-          type: "header",
-          text: {
-            type: "plain_text",
-            text: "Question & Bot's Answer",
-            emoji: true,
-          },
-        },
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: question,
-          },
-        },
-        {
-          type: "context",
-          elements: [
-            {
-              type: "plain_text",
-              text: answer,
-              emoji: true,
-            },
-          ],
-        },
-      ],
-    },
-  });
+        ],
+      },
+    });
 
-  // The result contains an identifier for the root view, view.id
-  console.log(`Successfully opened root view ${result.view?.id}`);
+    // The result contains an identifier for the root view, view.id
+    console.log(`Successfully opened root view ${result.view?.id}`);
+  } catch (error) {
+    console.error("Error opening modal:", error);
+    throw error;
+  }
 };
+
+async function submitToNotion(
+  question: string,
+  answer: string,
+  correct: boolean,
+  comment: string,
+  expertId: string,
+  slack_channel: string,
+  slack_thread_ts: string
+) {
+  try {
+    const response = await fetch(
+      `https://${process.env.VERCEL_URL}/api/slack/notion-interaction`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          question,
+          answer,
+          correct,
+          comment,
+          expertId,
+          slack_channel,
+          slack_thread_ts,
+        }),
+      }
+    );
+
+    const json = await response.json();
+    console.log({ json });
+    console.log("Submitted to Notion successfully");
+    return new Response(JSON.stringify({ response_action: "clear" }));
+  } catch (error) {
+    console.log("Failed to submit to Notion:", error);
+  }
+}

--- a/slack/api/slack/notion-interaction.ts
+++ b/slack/api/slack/notion-interaction.ts
@@ -1,0 +1,89 @@
+import { Client } from "@notionhq/client";
+import { VercelRequest, VercelResponse } from "@vercel/node";
+import { WebClient } from "@slack/web-api";
+
+const web = new WebClient(process.env.SLACK_TOKEN);
+
+const notion = new Client({ auth: process.env.NOTION_API_SECRET });
+
+export default async function notionInteractionHandler(
+  req: VercelRequest,
+  res: VercelResponse
+) {
+  try {
+    const {
+      question,
+      answer,
+      correct,
+      comment,
+      expertId,
+      slack_channel,
+      slack_thread_ts,
+    } = req.body;
+
+    console.log("Received expert feedback:", req.body);
+
+    const expertName = expertId.name;
+
+    const response = await saveExpertFeedbackToNotion(
+      question,
+      answer,
+      correct,
+      comment,
+      expertName,
+      slack_channel,
+      slack_thread_ts
+    );
+
+    console.log("Notion response:", response);
+
+    res.status(200).json({ message: "Expert feedback saved to Notion." });
+  } catch (error) {
+    console.error("Error handling Notion interaction:", error);
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+}
+
+async function saveExpertFeedbackToNotion(
+  question: string,
+  answer: string,
+  correct: boolean,
+  comment: string,
+  expertName: string,
+  slack_channel: string,
+  slack_thread_ts: string
+) {
+  const taskData = {
+    parent: { database_id: "083bf4cbaf134f7a940444e847e49126" },
+    properties: {
+      "Original Question": { title: [{ text: { content: question } }] },
+      Status: { multi_select: [{ name: "Submited" }] },
+      Priority: { multi_select: [{ name: "Medium" }] },
+      "Law Bot Answer": { rich_text: [{ text: { content: answer } }] },
+      Correctness: { checkbox: correct },
+      "Expert Comment": { rich_text: [{ text: { content: comment } }] },
+      Expert: { rich_text: [{ text: { content: expertName } }] },
+    },
+  };
+
+  const response = await notion.pages.create(taskData);
+
+  if (response) {
+    const message = `Expert feedback saved to Notion: ${response.url}`;
+    await sendSlackMessage(message, slack_channel, slack_thread_ts);
+  }
+
+  return response;
+}
+
+async function sendSlackMessage(
+  message: string,
+  slack_channel: string,
+  slack_thread_ts: string
+) {
+  await web.chat.postMessage({
+    channel: slack_channel,
+    text: message,
+    thread_ts: slack_thread_ts,
+  });
+}

--- a/slack/api/slack/process-events.ts
+++ b/slack/api/slack/process-events.ts
@@ -31,6 +31,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const payload_value = JSON.stringify({
       user_input: data.event.text,
       ai_response: json.data.content,
+      slack_channel: data.event.channel,
+      slack_thread_ts: data.event.ts,
     });
 
     const messageBlocks = [


### PR DESCRIPTION
@droegier

This PR implements the integration between Slack and Notion for managing expert feedback.

When a user submits feedback through a Slack modal, the interaction is handled to save the feedback as a task in Notion. Additionally, a message is sent back to the Slack thread confirming the creation of the task and providing a link to the Notion task.
