### PR TITLE
Chat History fix

### DIFF
--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -51,7 +51,13 @@ export async function POST(req: Request) {
     userId,
     createdAt,
     path,
-    body: completion
+    messages: [
+      ...messages,
+      {
+        content: completion,
+        role: 'assistant'
+      }
+    ]
   }
 
   await kv.hmset(`chat:${id}`, payload)


### PR DESCRIPTION
@droegier 

This PR addresses the bug reported on Slack - [Notion Task](https://www.notion.so/jurata/The-conversation-history-doesn-t-seem-to-work-5518a901b013440da75555f3e852208d?pvs=4)

I corrected the structure of the payload sent to the database, as it wasn't the same as the original boilerplate.
However, please note that due to the incorrect payload structure, past conversation history may not be retrieved even after the fix. It will only work for new chats moving forward.

Please feel free to test it on the preview Vercel deployment, as I still don't have access.